### PR TITLE
[signature header] Fix array of possible header bytes

### DIFF
--- a/bitcoin_message_tool/bmt.py
+++ b/bitcoin_message_tool/bmt.py
@@ -265,11 +265,11 @@ secp256k1 = EllipticCurve(p_curve=P_CURVE, n_curve=N_CURVE,
 
 
 precomputes: list[JacobianPoint] = []
-headers = [[b'\x1b', b'\x1c', b'\x1d', b'\x1e'],
-           [b'\x1f', b'\x1f', b'\x20', b'\x22'],
-           [b'\x23', b'\x24', b'\x25', b'\x26'],
-           [b'\x27', b'\x29', b'\x28', b'\x2a'],
-           [b'\x2b', b'\x2c', b'\x2d', b'\x2e']]
+headers = [[b'\x1b', b'\x1c', b'\x1d', b'\x1e'],  # 27 - 30 P2PKH uncompressed
+           [b'\x1f', b'\x20', b'\x21', b'\x22'],  # 31 - 34 P2PKH compressed
+           [b'\x23', b'\x24', b'\x25', b'\x26'],  # 35 - 38 P2WPKH-P2SH compressed (BIP-137)
+           [b'\x27', b'\x28', b'\x29', b'\x2a'],  # 39 - 42 P2WPKH compressed (BIP-137)
+           [b'\x2b', b'\x2c', b'\x2d', b'\x2e']]  # 43 - 46
 
 
 def double_sha256(b: bytes) -> bytes:


### PR DESCRIPTION
Hi! Thank you for making such a fantastic tool. It's really helped me understand how message signing works.

This PR fixes the array of possible bytes that the signature [header can be](https://en.bitcoin.it/wiki/Message_signing#Detailed_specification_of_the_message_signature). Some of the hex values were missing and some were (mistakenly?) repeated. I've also added comments for the ranges that each set of bytes correspond to, however I didn't know what the 43 - 46 range was.